### PR TITLE
Screenshot actual window coordinates

### DIFF
--- a/collecting-data-for-larger-fpv-model.py
+++ b/collecting-data-for-larger-fpv-model.py
@@ -82,7 +82,7 @@ def main():
 
         if not paused:
             # 800x600 windowed mode
-            screen = grab_screen(region=(0,40,800,640))
+            screen = grab_screen(title='Grand Theft Auto V')
             last_time = time.time()
             screen = cv2.cvtColor(screen, cv2.COLOR_BGR2GRAY)
             screen = cv2.resize(screen, (160,120))

--- a/grabscreen.py
+++ b/grabscreen.py
@@ -5,30 +5,20 @@ import numpy as np
 import win32gui, win32ui, win32con, win32api
 
 def grab_screen(region=None, title=None):
-
+    hwin = win32gui.GetDesktopWindow()
     if region:
-        hwin = win32gui.GetDesktopWindow()
         left,top,x2,y2 = region
         width = x2 - left + 1
         height = y2 - top + 1
     elif title:
-        hwin = win32gui.FindWindow(None, title)
-        if not hwin:
+        gtawin = win32gui.FindWindow(None, title)
+        if not gtawin:
             raise Exception('window title not found')
         #get the bounding box of the window
-        win_left, win_top, win_x2, win_y2 = win32gui.GetWindowRect(hwin)
-        # get the box of the client part, left and top are always 0,0 so x2,y2
-        # are always height and width
-        left, top, width, height = win32gui.GetClientRect(hwin)
-        win_width = win_x2 - win_left +1
-        win_height = win_y2 - win_top +1
-        # differnce in the H and W are the bounding of the title bar and window
-        x_scale = win_width // width
-        y_scale = win_height // height
-        left = win_width - width * x_scale
-        top = win_height - height * y_scale
+        left, top, x2, y2 = win32gui.GetWindowRect(gtawin)
+        width = x2 - left +1
+        height = y2 - top +1
     else:
-        hwin = win32gui.GetDesktopWindow()
         width = win32api.GetSystemMetrics(win32con.SM_CXVIRTUALSCREEN)
         height = win32api.GetSystemMetrics(win32con.SM_CYVIRTUALSCREEN)
         left = win32api.GetSystemMetrics(win32con.SM_XVIRTUALSCREEN)

--- a/grabscreen.py
+++ b/grabscreen.py
@@ -23,8 +23,10 @@ def grab_screen(region=None, title=None):
         win_width = win_x2 - win_left +1
         win_height = win_y2 - win_top +1
         # differnce in the H and W are the bounding of the title bar and window
-        left = win_width - width
-        top = win_height - height
+        x_scale = win_width // width
+        y_scale = win_height // height
+        left = win_width - width * x_scale
+        top = win_height - height * y_scale
     else:
         hwin = win32gui.GetDesktopWindow()
         width = win32api.GetSystemMetrics(win32con.SM_CXVIRTUALSCREEN)

--- a/grabscreen.py
+++ b/grabscreen.py
@@ -4,15 +4,29 @@ import cv2
 import numpy as np
 import win32gui, win32ui, win32con, win32api
 
-def grab_screen(region=None):
-
-    hwin = win32gui.GetDesktopWindow()
+def grab_screen(region=None, title=None):
 
     if region:
-            left,top,x2,y2 = region
-            width = x2 - left + 1
-            height = y2 - top + 1
+        hwin = win32gui.GetDesktopWindow()
+        left,top,x2,y2 = region
+        width = x2 - left + 1
+        height = y2 - top + 1
+    elif title:
+        hwin = win32gui.FindWindow(None, title)
+        if not hwin:
+            raise Exception('window title not found')
+        #get the bounding box of the window
+        win_left, win_top, win_x2, win_y2 = win32gui.GetWindowRect(hwin)
+        # get the box of the client part, left and top are always 0,0 so x2,y2
+        # are always height and width
+        left, top, width, height = win32gui.GetClientRect(hwin)
+        win_width = win_x2 - win_left +1
+        win_height = win_y2 - win_top +1
+        # differnce in the H and W are the bounding of the title bar and window
+        left = win_width - width
+        top = win_height - height
     else:
+        hwin = win32gui.GetDesktopWindow()
         width = win32api.GetSystemMetrics(win32con.SM_CXVIRTUALSCREEN)
         height = win32api.GetSystemMetrics(win32con.SM_CYVIRTUALSCREEN)
         left = win32api.GetSystemMetrics(win32con.SM_XVIRTUALSCREEN)


### PR DESCRIPTION
Screenshots the GTA V window based on the title of the window using the pywin32 for the screenshot. When screenshotting by the title, it will automatically calculate the width and height of the title bar and border to crop out. Additionally when screenshotting based on title, it will grab the actual window, even if buried underneath other windows.

Unlike #22, this still uses the faster screenshot of grab screen. I also believe #22 does not crop the title bar.

Limitation: I believe this breaks on full screen, but works flawlessly for me on window and borderless window.